### PR TITLE
Use SvLEN_set/SvCUR_set in a few extra locations

### DIFF
--- a/gv.c
+++ b/gv.c
@@ -1271,7 +1271,7 @@ Perl_gv_autoload_pvn(pTHX_ HV *stash, const char *name, STRLEN len, U32 flags)
 	    sv_setsv_nomg((SV *)cv, tmpsv);
 	    SvTEMP_off(tmpsv);
 	    SvREFCNT_dec_NN(tmpsv);
-	    SvLEN(cv) = SvCUR(cv) + 1;
+	    SvLEN_set(cv, SvCUR(cv) + 1);
 	    SvCUR(cv) = ulen;
 	}
 	else {

--- a/toke.c
+++ b/toke.c
@@ -4443,8 +4443,8 @@ Perl_filter_add(pTHX_ filter_t funcp, SV *datasv)
 		    PL_parser->last_uni = buf + last_uni_pos;
 		if (PL_parser->last_lop)
 		    PL_parser->last_lop = buf + last_lop_pos;
-		SvLEN(linestr) = SvCUR(linestr);
-		SvCUR(linestr) = s-SvPVX(linestr);
+		SvLEN_set(linestr, SvCUR(linestr));
+		SvCUR_set(linestr, s - SvPVX(linestr));
 		PL_parser->filtered = 1;
 		break;
 	    }

--- a/universal.c
+++ b/universal.c
@@ -225,8 +225,8 @@ Perl_sv_does_sv(pTHX_ SV *sv, SV *namesv, U32 flags)
     /* create a PV with value "isa", but with a special address
      * so that perl knows we're really doing "DOES" instead */
     methodname = newSV_type(SVt_PV);
-    SvLEN(methodname) = 0;
-    SvCUR(methodname) = strlen(PL_isa_DOES);
+    SvLEN_set(methodname, 0);
+    SvCUR_set(methodname, strlen(PL_isa_DOES));
     SvPVX(methodname) = (char *)PL_isa_DOES; /* discard 'const' qualifier */
     SvPOK_on(methodname);
     sv_2mortal(methodname);


### PR DESCRIPTION
SvLEN was set without using the generic macro SvLEN_set.
Use it in three extra locations, and also use SvCUR_set
instead of SvCUR.