### PR TITLE
Fixup REPORT_LOCATION_ARGS to use positive length RT 132163

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -3658,6 +3658,8 @@ L<perlfunc/require EXPR> and L<perlfunc/do EXPR>.
 
 =item Missing right brace on \%c{} in regex; marked by S<<-- HERE> in m/%s/
 
+=item Missing right brace on \N{} in regex; marked by S<<-- HERE> in m/%s/
+
 (F) Missing right brace in C<\x{...}>, C<\p{...}>, C<\P{...}>, or C<\N{...}>.
 
 =item Missing right brace on \N{}

--- a/regcomp.c
+++ b/regcomp.c
@@ -628,7 +628,7 @@ static const scan_data_t zero_scan_data = {
     UTF8fARG(UTF,                                                           \
              (xI(xC) > eC) /* Don't run off end */                          \
               ? eC - sC   /* Length before the <--HERE */                   \
-              : xI_offset(xC),                                              \
+              : ( xI_offset(xC) > 0 ? xI_offset(xC) : 0 ),                  \
              sC),         /* The input pattern printed up to the <--HERE */ \
     UTF8fARG(UTF,                                                           \
              (xI(xC) > eC) ? 0 : eC - xI(xC), /* Length after <--HERE */    \
@@ -12056,7 +12056,7 @@ S_grok_bslash_N(pTHX_ RExC_state_t *pRExC_state,
 
     endbrace = strchr(RExC_parse, '}');
     if (! endbrace) { /* no trailing brace */
-        vFAIL2("Missing right brace on \\%c{}", 'N');
+        vFAIL("Missing right brace on \\N{}");
     }
     else if(!(endbrace == RExC_parse		/* nothing between the {} */
               || (endbrace - RExC_parse >= 2	/* U+ (bad hex is checked... */

--- a/t/re/re_tests
+++ b/t/re/re_tests
@@ -1941,6 +1941,7 @@ A+(*PRUNE)BC(?{})	AAABC	y	$&	AAABC
 /w\z\R\z/i	\x{100}a\x{80}a	n	-	-
 
 /(a+){1}+a/	aaa	n	-	-		# [perl #125825]
+[\0\N{U+.}	aaa	c	-	Unmatched [ in regex; marked by <-- HERE in m/\[ <-- HERE \\0\\N{U+.}/	# [perl #132163]
 
 ^((?(?=x)xb|ya)z)	xbz	y	$1	xbz
 ^((?(?=x)xb|ya)z)	yaz	y	$1	yaz


### PR DESCRIPTION
Use vFAIL instead of vFAIL2, and adjust the length
when the offset is negative.

https://rt.perl.org/Public/Bug/Display.html?id=132163