### PR TITLE
Skip two extra t/porting tests when using distro packaging

### DIFF
--- a/t/porting/authors.t
+++ b/t/porting/authors.t
@@ -9,6 +9,7 @@ use strict;
 
 require './t/test.pl';
 find_git_or_skip('all');
+skip_all("This distro may have modified some files in cpan/. Skipping validation.") if $ENV{'PERL_BUILD_PACKAGING'};
 
 # This is the subset of "pretty=fuller" that checkAUTHORS.pl actually needs:
 my $quote = $^O =~ /^mswin/i ? q(") : q(');

--- a/t/porting/podcheck.t
+++ b/t/porting/podcheck.t
@@ -29,6 +29,10 @@ BEGIN {
         print "1..0 # $^O cannot handle this test\n";
         exit(0);
     }
+    if ( $ENV{'PERL_BUILD_PACKAGING'} ) {
+        print "1..0 # This distro may have modified some files in cpan/. Skipping validation. \n";
+        exit 0;
+    }
     require '../regen/regen_lib.pl';
 }
 


### PR DESCRIPTION
PERL_BUILD_PACKAGING=1 should skip t/porting/authors.t and t/porting/podcheck.t