### PR TITLE
Use clang compiler on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 
 compiler:
   - gcc
+  - clang
 
 env:
     global:
@@ -13,6 +14,13 @@ env:
     matrix:
         - CONFIGURE_ARGS='-Uusethreads'
         - CONFIGURE_ARGS='-Dusethreads'
+
+matrix:
+  exclude:
+  - compiler: clang
+    os: linux
+  - compiler: gcc
+    os: osx
 
 script:
   - ./Configure -des -Dusedevel -Uversiononly -Dcc=$CC $CONFIGURE_ARGS -Dprefix=$HOME/perl-blead -DDEBUGGING && TEST_JOBS=8 make -j8 test_harness_notty && make -j8 install && $HOME/perl-blead/bin/perlivp


### PR DESCRIPTION
Without any extra cost we can use clang on osx
by providing some custom matrix/exclude rules.

Note that we could even improve the osx setting by using
one build with clang and the other one with gcc
depending if we are building perl with or without threads
but this would slightly increase the exclude rules length.

Note: as we are changing travis.yaml file an extra build is required to use it