### PR TITLE
Storable: remove Config dependency

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3661,6 +3661,7 @@ dist/SelfLoader/lib/SelfLoader.pm	Load functions only on demand
 dist/SelfLoader/t/01SelfLoader.t	See if SelfLoader works
 dist/SelfLoader/t/02SelfLoader-buggy.t	See if SelfLoader works
 dist/SelfLoader/t/03taint.t		See if SelfLoader works under taint
+dist/Storable/__Storable__.pm	Template to generate Storable.pm
 dist/Storable/ChangeLog			Storable extension
 dist/Storable/hints/gnukfreebsd.pl	Hint for Storable for named architecture
 dist/Storable/hints/gnuknetbsd.pl	Hint for Storable for named architecture
@@ -3668,8 +3669,8 @@ dist/Storable/hints/hpux.pl		Hint for Storable for named architecture
 dist/Storable/hints/linux.pl		Hint for Storable for named architecture
 dist/Storable/Makefile.PL		Storable extension
 dist/Storable/README			Storable extension
-dist/Storable/Storable.pm		Storable extension
 dist/Storable/Storable.xs		Storable extension
+dist/Storable/Storable.pm.PL	perl script to generate Storable.pm from template
 dist/Storable/t/attach.t		Check STORABLE_attach doesn't create objects unnecessarily
 dist/Storable/t/attach_errors.t		Trigger and test STORABLE_attach errors
 dist/Storable/t/attach_singleton.t	Test STORABLE_attach for the Singleton pattern

--- a/dist/Storable/.gitignore
+++ b/dist/Storable/.gitignore
@@ -1,0 +1,1 @@
+/Storable.pm

--- a/dist/Storable/ChangeLog
+++ b/dist/Storable/ChangeLog
@@ -1,3 +1,9 @@
+?????? p5p <perl5-porters@perl.org>
+    Version 2.65
+
+	* Replace multiple 'use vars' by 'our'
+	* remove Config dependency 
+
 Wed Jul  2 16:25:25 IST 2014   Abhijit Menon-Sen <ams@toroid.org>
     Version 2.51
 

--- a/dist/Storable/Makefile.PL
+++ b/dist/Storable/Makefile.PL
@@ -13,16 +13,30 @@ WriteMakefile(
     DISTNAME            => "Storable",
 # We now ship this in t/
 #    PREREQ_PM           => { 'Test::More' => '0.41' },
+    PL_FILES        => { 'Storable.pm.PL'  => 'Storable.pm' },
+    PM              => { 'Storable.pm' => '$(INST_ARCHLIB)/Storable.pm' },
     PREREQ_PM           => { XSLoader => 0 },
     INSTALLDIRS => ($] >= 5.007 && $] < 5.012) ? 'perl' : 'site',
-    VERSION_FROM        => 'Storable.pm',
+    VERSION_FROM    => '__Storable__.pm',
+    ABSTRACT_FROM   => '__Storable__.pm',
     ($ExtUtils::MakeMaker::VERSION > 6.45 ?
      (META_MERGE        => { resources =>
-                               { bugtracker => 'http://rt.perl.org/perlbug/' }
+                               { bugtracker => 'http://rt.perl.org/perlbug/' },
+                            provides    => {
+                                'Storable'  => {
+                                    file        => 'Storable_pm.PL',
+                                    version     => $NEW_VERSION,
+                                },
+                            },
+
                            },
     ) : ()),
     dist                => { SUFFIX => 'gz', COMPRESS => 'gzip -f' },
+    clean               => { FILES => 'Storable-* Storable.pm' },
 );
+
+# Unlink the .pm file included with the distribution
+1 while unlink "Storable.pm";
 
 my $ivtype = $Config{ivtype};
 

--- a/dist/Storable/Storable.pm.PL
+++ b/dist/Storable/Storable.pm.PL
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+
+use Config;
+
+my $template;
+{	# keep all the code in an external template to keep it easy to update
+	local $/;
+	open my $FROM, '<', '__Storable__.pm' or die $!;
+	$template = <$FROM>;
+	close $FROM or die $!;
+}
+
+sub CAN_FLOCK {
+	return
+		$Config{'d_flock'} ||
+		$Config{'d_fcntl_can_lock'} ||
+		$Config{'d_lockf'}
+		? 1 : 0;
+}
+
+my $CAN_FLOCK = CAN_FLOCK();
+
+# populate the sub and preserve it if used outside
+$template =~ s{^sub CAN_FLOCK;.*$}{sub CAN_FLOCK { ${CAN_FLOCK} } # computed by Storable.pm.PL}m;
+# alternatively we could remove the sub
+#$template =~ s{^sub CAN_FLOCK;.*$}{}m;
+# replace local function calls to hardcoded value
+$template =~ s{&CAN_FLOCK}{${CAN_FLOCK}}g;
+
+{
+	open my $OUT, '>', 'Storable.pm' or die $!;
+	print {$OUT} $template or die $!;
+	close $OUT or die $!;
+}

--- a/dist/Storable/__Storable__.pm
+++ b/dist/Storable/__Storable__.pm
@@ -84,14 +84,7 @@ XSLoader::load('Storable', $Storable::VERSION);
 # Determine whether locking is possible, but only when needed.
 #
 
-sub CAN_FLOCK; my $CAN_FLOCK; sub CAN_FLOCK {
-	return $CAN_FLOCK if defined $CAN_FLOCK;
-	require Config; import Config;
-	return $CAN_FLOCK =
-		$Config{'d_flock'} ||
-		$Config{'d_fcntl_can_lock'} ||
-		$Config{'d_lockf'};
-}
+sub CAN_FLOCK; # TEMPLATE - replaced by Storable.pm.PL
 
 sub show_file_magic {
     print <<EOM;


### PR DESCRIPTION
Avoid loading Config/Config_heavy from Storable.

Make Storable.pm a template file and check
if the system can use flock at compile time.

__Storable__.pm is the template file to edit,
whereas Storable.pm.PL is the script generating
Storable.pm from __Storable__.pm.

Using a separate file for the template make it
easier to edit.

Also note that Storable.pm is now ignored by git.