### PR TITLE
Time::HiRes disable a flapping test for CI

### DIFF
--- a/PACKAGING
+++ b/PACKAGING
@@ -36,4 +36,15 @@ standalone Perl script.
 
 		perl -x patchlevel.h "This is a custom patch"
 
+=head1 Disabling known flapping tests
+
+Some tests could fail under heavy load, whereas in most cases
+they would simply succeeds. Usually continuous integration systems
+will at one point or the other reach that problem.
+
+To disable these known tests, please set the environment variable
+CI to true.
+
+        CI=true
+
 =cut

--- a/dist/Time-HiRes/t/nanosleep.t
+++ b/dist/Time-HiRes/t/nanosleep.t
@@ -8,7 +8,7 @@ BEGIN {
     }
 }
 
-use Test::More tests => 3;
+use Test::More tests => 4;
 BEGIN { push @INC, '.' }
 use t::Watchdog;
 
@@ -25,12 +25,14 @@ ok $one == $two || $two == $three
     or print("# slept too long, $one $two $three\n");
 
 SKIP: {
-    skip "no gettimeofday", 1 unless &Time::HiRes::d_gettimeofday;
+    skip "no gettimeofday", 2 unless &Time::HiRes::d_gettimeofday;
     my $f = Time::HiRes::time();
     Time::HiRes::nanosleep(500_000_000);
     my $f2 = Time::HiRes::time();
     my $d = $f2 - $f;
-    ok $d > 0.4 && $d < 0.9 or print("# slept $d secs $f to $f2\n");
+    cmp_ok $d, '>', 0.4, "nanosleep for more than 0.4 sec";
+    skip "flapping test - more than 0.9 sec could be necessary...", 1 if $ENV{CI};
+    cmp_ok $d, '<', 0.9 or diag("# slept $d secs $f to $f2\n");
 }
 
 1;


### PR DESCRIPTION
When running this test under heavy load
we cannot assume the delta between two system calls...
even when using a (nano)sleep

Most Continuous Integration system will fail on this
test at one point or the other.