### PR TITLE
DynaLoader simplify parsing option rule

### DIFF
--- a/ext/DynaLoader/DynaLoader_pm.PL
+++ b/ext/DynaLoader/DynaLoader_pm.PL
@@ -85,7 +85,7 @@ package DynaLoader;
 # Tim.Bunce@ig.co.uk, August 1994
 
 BEGIN {
-    $VERSION = '1.43';
+    $VERSION = '1.44';
 }
 
 EOT
@@ -454,7 +454,7 @@ sub dl_findfile {
 
         # Deal with directories first:
         #  Using a -L prefix is the preferred option (faster and more robust)
-        if (index($_,'-L') == 0) { substr($_,0,2,''); push(@dirs, $_); next; }
+        if ( s{^-L}{} ) { push(@dirs, $_); next; }
 
         #  Otherwise we try to try to spot directories by a heuristic
         #  (this is a more complicated issue than it first appears)
@@ -468,10 +468,8 @@ sub dl_findfile {
 
         #  Only files should get this far...
         my(@names, $name);    # what filenames to look for
-        if (index($_,'-l') == 0) {          # convert -lname to appropriate library name
-            substr($_,0,2,'');
-            push(@names,"lib$_.$dl_so");
-            push(@names,"lib$_.a");
+        if ( s{^-l}{} ) {          # convert -lname to appropriate library name
+            push(@names, "lib$_.$dl_so", "lib$_.a");
         } else {                # Umm, a bare name. Try various alternatives:
             # these should be ordered with the most likely first
             push(@names,"$_.$dl_dlext")    unless m/\.$dl_dlext$/o;


### PR DESCRIPTION
After review, comments & dumb benchmark.
Simply using a substitute for these two
'-L' and '-l' options parsing makes the code
easier to maintain.

The benchmark difference is pretty close, for
matching, non matching (short or long) strings.