### PR TITLE
Carp: optimize format_arg when arguments contain many references

### DIFF
--- a/dist/Carp/Changes
+++ b/dist/Carp/Changes
@@ -1,3 +1,7 @@
+version 1.44
+
+  * Optimize format_arg when arguments contain many references
+
 version 1.43
 
   * fix problems introduced by the partial EBCDIC support from version

--- a/dist/Carp/lib/Carp.pm
+++ b/dist/Carp/lib/Carp.pm
@@ -283,8 +283,13 @@ sub format_arg {
     my $arg = shift;
 
     if ( ref($arg) ) {
+
+        # lazy check if the CPAN module UNIVERSAL::isa is used or not
+        #   if we use a rogue version of UNIVERSAL this would lead to infinite loop
+        my $isa = $UNIVERSAL::isa::VERSION ? sub { 1 } : \&UNIVERSAL::isa;
+
          # legitimate, let's not leak it.
-        if (!$in_recurse &&
+        if (!$in_recurse && $isa->( $arg, 'UNIVERSAL' ) &&
 	    do {
                 local $@;
 	        local $in_recurse = 1;


### PR DESCRIPTION
RT #132274

This is a very minimal patch after RT discussion.