### PR TITLE
Storable: add a flag to control 'bless' and 'tie'

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3689,6 +3689,7 @@ dist/Storable/t/dclone.t		See if Storable works
 dist/Storable/t/destroy.t		Test Storable in global destructon
 dist/Storable/t/downgrade.t		See if Storable works
 dist/Storable/t/file_magic.t		See if file_magic function works
+dist/Storable/t/flags.t			See if Storable works
 dist/Storable/t/forgive.t		See if Storable works
 dist/Storable/t/freeze.t		See if Storable works
 dist/Storable/t/HAS_ATTACH.pm		For auto-requiring of modules for STORABLE_attach

--- a/dist/Storable/ChangeLog
+++ b/dist/Storable/ChangeLog
@@ -1,8 +1,13 @@
 ?????? p5p <perl5-porters@perl.org>
-    Version 2.65
+    Version 2.66
+
+	* Introduce Storable::flags to control 'bless' and 'tie'
+
+Mon Nov 20 14:20:33 PST 2017   Karen Etheridge <ether@cpan.org>
+	Version 2.65
 
 	* Replace multiple 'use vars' by 'our'
-	* remove Config dependency
+	* Remove Config dependency
 
 Wed Jul  2 16:25:25 IST 2014   Abhijit Menon-Sen <ams@toroid.org>
     Version 2.51

--- a/dist/Storable/Storable.xs
+++ b/dist/Storable/Storable.xs
@@ -344,6 +344,7 @@ typedef struct stcxt {
 	SV *prev;		/* contexts chained backwards in real recursion */
 	SV *my_sv;		/* the blessed scalar who's SvPVX() I am */
 	int in_retrieve_overloaded; /* performance hack for retrieving overloaded objects */
+	int flags;		/* controls whether to bless or tie objects */
 } stcxt_t;
 
 static int storable_free(pTHX_ SV *sv, MAGIC* mg);
@@ -769,6 +770,12 @@ static stcxt_t *Context_ptr = NULL;
 #define SHV_K_PLACEHOLDER	0x10
 
 /*
+ * flags to allow blessing and/or tieing data the data we load
+ */
+#define FLAG_BLESS_OK 2
+#define FLAG_TIE_OK 4
+
+/*
  * Before 0.6, the magic string was "perl-store" (binary version number 0).
  *
  * Since 0.6 introduced many binary incompatibilities, the magic string has
@@ -1083,16 +1090,21 @@ static const char byteorderstr_56[] = {BYTEORDER_BYTES_56, 0};
 #define BLESS(s,stash) 						\
   STMT_START {								\
 	SV *ref;								\
-	TRACEME(("blessing 0x%" UVxf " in %s", PTR2UV(s), (HvNAME_get(stash))));\
-	ref = newRV_noinc(s);					\
-	if (cxt->in_retrieve_overloaded && Gv_AMG(stash)) \
-	{ \
-	    cxt->in_retrieve_overloaded = 0; \
-		SvAMAGIC_on(ref);                            \
+	if (cxt->flags & FLAG_BLESS_OK) {		\
+		TRACEME(("blessing 0x%" UVxf " in %s", PTR2UV(s), (HvNAME_get(stash)))); \
+		ref = newRV_noinc(s);					\
+		if (cxt->in_retrieve_overloaded && Gv_AMG(stash)) \
+		{ \
+		    cxt->in_retrieve_overloaded = 0; \
+			SvAMAGIC_on(ref);                            \
+		} \
+		(void) sv_bless(ref, stash);			\
+		SvRV_set(ref, NULL);						\
+		SvREFCNT_dec(ref);						\
 	} \
-	(void) sv_bless(ref, stash);			\
-	SvRV_set(ref, NULL);						\
-	SvREFCNT_dec(ref);						\
+	else {									\
+		TRACEME(("not blessing 0x%"UVxf" in %s", PTR2UV(s), (p))); \
+	}										\
   } STMT_END
 /*
  * sort (used in store_hash) - conditionally use qsort when
@@ -4372,6 +4384,15 @@ static SV *retrieve_hook(pTHX_ stcxt_t *cxt, const char *cname)
 
 	/*
 	 * Look up the STORABLE_attach hook
+	 * If blessing is disabled, just return what we've got.
+	 */
+	if (!(cxt->flags & FLAG_BLESS_OK)) {
+		TRACEME(("skipping bless because flags is %d", cxt->flags));
+		return sv;
+	}
+
+	/*
+	 * Bless the object and look up the STORABLE_thaw hook.
 	 */
 	stash = gv_stashpv(classname, GV_ADD);
 
@@ -4420,33 +4441,9 @@ static SV *retrieve_hook(pTHX_ stcxt_t *cxt, const char *cname)
 
 	BLESS(sv, stash);
 
-	hook = pkg_can(aTHX_ cxt->hook, stash, "STORABLE_thaw");
-	if (!hook) {
-		/*
-		 * Hook not found.  Maybe they did not require the module where this
-		 * hook is defined yet?
-		 *
-		 * If the load below succeeds, we'll be able to find the hook.
-		 * Still, it only works reliably when each class is defined in a
-		 * file of its own.
-		 */
-
-		TRACEME(("No STORABLE_thaw defined for objects of class %s", classname));
-		TRACEME(("Going to load module '%s'", classname));
-	        load_module(PERL_LOADMOD_NOIMPORT, newSVpv(classname, 0), Nullsv);
-
-		/*
-		 * We cache results of pkg_can, so we need to uncache before attempting
-		 * the lookup again.
-		 */
-
-		pkg_uncache(aTHX_ cxt->hook, SvSTASH(sv), "STORABLE_thaw");
-		hook = pkg_can(aTHX_ cxt->hook, SvSTASH(sv), "STORABLE_thaw");
-
-		if (!hook)
-			CROAK(("No STORABLE_thaw defined for objects of class %s "
-					"(even after a \"require %s;\")", classname, classname));
-	}
+	hook = pkg_can(aTHX_ cxt->hook, SvSTASH(sv), "STORABLE_thaw");
+	if (!hook)
+		CROAK(("No STORABLE_thaw defined for objects of class %s", classname));
 
 	/*
 	 * If we don't have an 'av' yet, prepare one.
@@ -4684,17 +4681,10 @@ static SV *retrieve_overloaded(pTHX_ stcxt_t *cxt, const char *cname)
 		       PTR2UV(sv)));
 	}
 	if (!Gv_AMG(stash)) {
-	        const char *package = HvNAME_get(stash);
-		TRACEME(("No overloading defined for package %s", package));
-		TRACEME(("Going to load module '%s'", package));
-		load_module(PERL_LOADMOD_NOIMPORT, newSVpv(package, 0), Nullsv);
-		if (!Gv_AMG(stash)) {
-			CROAK(("Cannot restore overloading on %s(0x%" UVxf
-			       ") (package %s) (even after a \"require %s;\")",
-			       sv_reftype(sv, FALSE),
-			       PTR2UV(sv),
-			       package, package));
-		}
+		CROAK(("Cannot restore overloading on %s(0x%" UVxf
+		       ") (package %s)",
+		       sv_reftype(sv, FALSE),
+		       PTR2UV(sv)));
 	}
 
 	SvAMAGIC_on(rv);
@@ -4741,6 +4731,10 @@ static SV *retrieve_tied_array(pTHX_ stcxt_t *cxt, const char *cname)
 
 	TRACEME(("retrieve_tied_array (#%d)", cxt->tagnum));
 
+	if (!(cxt->flags & FLAG_TIE_OK)) {
+		CROAK(("Tying is disabled."));
+	}
+
 	tv = NEWSV(10002, 0);
 	stash = cname ? gv_stashpv(cname, GV_ADD) : 0;
 	SEEN_NN(tv, stash, 0);			/* Will return if tv is null */
@@ -4772,6 +4766,10 @@ static SV *retrieve_tied_hash(pTHX_ stcxt_t *cxt, const char *cname)
 
 	TRACEME(("retrieve_tied_hash (#%d)", cxt->tagnum));
 
+	if (!(cxt->flags & FLAG_TIE_OK)) {
+		CROAK(("Tying is disabled."));
+	}
+
 	tv = NEWSV(10002, 0);
 	stash = cname ? gv_stashpv(cname, GV_ADD) : 0;
 	SEEN_NN(tv, stash, 0);			/* Will return if tv is null */
@@ -4801,6 +4799,10 @@ static SV *retrieve_tied_scalar(pTHX_ stcxt_t *cxt, const char *cname)
 	HV *stash;
 
 	TRACEME(("retrieve_tied_scalar (#%d)", cxt->tagnum));
+
+	if (!(cxt->flags & FLAG_TIE_OK)) {
+		CROAK(("Tying is disabled."));
+	}
 
 	tv = NEWSV(10002, 0);
 	stash = cname ? gv_stashpv(cname, GV_ADD) : 0;
@@ -4841,6 +4843,10 @@ static SV *retrieve_tied_key(pTHX_ stcxt_t *cxt, const char *cname)
 
 	TRACEME(("retrieve_tied_key (#%d)", cxt->tagnum));
 
+	if (!(cxt->flags & FLAG_TIE_OK)) {
+		CROAK(("Tying is disabled."));
+	}
+
 	tv = NEWSV(10002, 0);
 	stash = cname ? gv_stashpv(cname, GV_ADD) : 0;
 	SEEN_NN(tv, stash, 0);			/* Will return if tv is null */
@@ -4874,6 +4880,10 @@ static SV *retrieve_tied_idx(pTHX_ stcxt_t *cxt, const char *cname)
 	I32 idx;
 
 	TRACEME(("retrieve_tied_idx (#%d)", cxt->tagnum));
+
+	if (!(cxt->flags & FLAG_TIE_OK)) {
+		CROAK(("Tying is disabled."));
+	}
 
 	tv = NEWSV(10002, 0);
 	stash = cname ? gv_stashpv(cname, GV_ADD) : 0;
@@ -6275,7 +6285,8 @@ static SV *do_retrieve(
         pTHX_
 	PerlIO *f,
 	SV *in,
-	int optype)
+	int optype,
+	int flags)
 {
 	dSTCXT;
 	SV *sv;
@@ -6283,8 +6294,10 @@ static SV *do_retrieve(
 	int pre_06_fmt = 0;			/* True with pre Storable 0.6 formats */
 
 	TRACEME(("do_retrieve (optype = 0x%x)", optype));
+	TRACEME(("do_retrieve (flags = 0x%x)", flags));
 
 	optype |= ST_RETRIEVE;
+	cxt->flags = flags;
 
 	/*
 	 * Sanity assertions for retrieve dispatch tables.
@@ -6311,8 +6324,10 @@ static SV *do_retrieve(
 	 * re-enter retrieve() via the hooks.
 	 */
 
-	if (cxt->entry)
+	if (cxt->entry) {
 		cxt = allocate_context(aTHX_ cxt);
+		cxt->flags = flags;
+	}
 
 	cxt->entry++;
 
@@ -6505,10 +6520,12 @@ static SV *do_retrieve(
  *
  * Retrieve data held in file and return the root object, undef on error.
  */
-static SV *pretrieve(pTHX_ PerlIO *f)
+static SV *pretrieve(pTHX_ PerlIO *f, SV *flag)
 {
+	int flags;
 	TRACEME(("pretrieve"));
-	return do_retrieve(aTHX_ f, Nullsv, 0);
+	flags = (int)SvIV(flag);
+	return do_retrieve(aTHX_ f, Nullsv, 0, flags);
 }
 
 /*
@@ -6516,10 +6533,12 @@ static SV *pretrieve(pTHX_ PerlIO *f)
  *
  * Retrieve data held in scalar and return the root object, undef on error.
  */
-static SV *mretrieve(pTHX_ SV *sv)
+static SV *mretrieve(pTHX_ SV *sv, SV *flag)
 {
+	int flags;
 	TRACEME(("mretrieve"));
-	return do_retrieve(aTHX_ (PerlIO*) 0, sv, 0);
+	flags = (int)SvIV(flag);
+	return do_retrieve(aTHX_ (PerlIO*) 0, sv, 0, flags);
 }
 
 /***
@@ -6604,7 +6623,7 @@ static SV *dclone(pTHX_ SV *sv)
 	 */
 
 	cxt->s_tainted = SvTAINTED(sv);
-	out = do_retrieve(aTHX_ (PerlIO*) 0, Nullsv, ST_CLONE);
+	out = do_retrieve(aTHX_ (PerlIO*) 0, Nullsv, ST_CLONE, FLAG_BLESS_OK | FLAG_TIE_OK);
 
 	TRACEME(("dclone returns 0x%" UVxf, PTR2UV(out)));
 
@@ -6717,18 +6736,20 @@ SV *	obj
   RETVAL
 
 SV *
-pretrieve(f)
+pretrieve(f, flag)
 InputStream	f
+SV *	flag
  CODE:
-  RETVAL = pretrieve(aTHX_ f);
+  RETVAL = pretrieve(aTHX_ f, flag);
  OUTPUT:
   RETVAL
 
 SV *
-mretrieve(sv)
+mretrieve(sv, flag)
 SV *	sv
+SV *	flag
  CODE:
-  RETVAL = mretrieve(aTHX_ sv);
+  RETVAL = mretrieve(aTHX_ sv, flag);
  OUTPUT:
   RETVAL
 

--- a/dist/Storable/__Storable__.pm
+++ b/dist/Storable/__Storable__.pm
@@ -19,11 +19,12 @@ our @EXPORT_OK = qw(
 	retrieve_fd
 	lock_store lock_nstore lock_retrieve
         file_magic read_magic
+    BLESS_OK TIE_OK FLAGS_COMPAT
 );
 
 our ($canonical, $forgive_me);
 
-our $VERSION = '2.65';
+our $VERSION = '2.66';
 
 BEGIN {
     if (eval {
@@ -73,8 +74,14 @@ sub CLONE {
     Storable::init_perinterp();
 }
 
+sub BLESS_OK 		{ 2 }
+sub TIE_OK 			{ 4 }
+sub FLAGS_COMPAT 	{ BLESS_OK() | TIE_OK() }
+
 # By default restricted hashes are downgraded on earlier perls.
 
+# default flag value: using for now FLAGS_COMPAT for backward compatibility
+$Storable::flags = FLAGS_COMPAT();
 $Storable::downgrade_restricted = 1;
 $Storable::accept_future_minor = 1;
 
@@ -351,7 +358,7 @@ sub _freeze {
 # object of that tree.
 #
 sub retrieve {
-	_retrieve($_[0], 0);
+	_retrieve($_[0], $_[1], 0);
 }
 
 #
@@ -360,12 +367,14 @@ sub retrieve {
 # Same as retrieve, but with advisory locking.
 #
 sub lock_retrieve {
-	_retrieve($_[0], 1);
+	_retrieve($_[0], $_[1], 1);
 }
 
 # Internal retrieve routine
 sub _retrieve {
-	my ($file, $use_locking) = @_;
+	my ($file, $flags, $use_locking) = @_;
+	$flags = $Storable::flags unless defined $flags;
+
 	local *FILE;
 	open(FILE, '<', $file) || logcroak "can't open $file: $!";
 	binmode FILE;							# Archaic systems...
@@ -380,7 +389,7 @@ sub _retrieve {
 		flock(FILE, LOCK_SH) || logcroak "can't get shared lock on $file: $!";
 		# Unlocking will happen when FILE is closed
 	}
-	eval { $self = pretrieve(*FILE) };		# Call C routine
+	eval { $self = pretrieve(*FILE, $flags) };		# Call C routine
 	close(FILE);
 	logcroak $@ if $@ =~ s/\.?\n$/,/;
 	$@ = $da;
@@ -393,12 +402,13 @@ sub _retrieve {
 # Same as retrieve, but perform from an already opened file descriptor instead.
 #
 sub fd_retrieve {
-	my ($file) = @_;
+	my ($file, $flags) = @_;
+	$flags = $Storable::flags unless defined $flags;
 	my $fd = fileno($file);
 	logcroak "not a valid file descriptor" unless defined $fd;
 	my $self;
 	my $da = $@;							# Could be from exception handler
-	eval { $self = pretrieve($file) };		# Call C routine
+	eval { $self = pretrieve($file, $flags) };		# Call C routine
 	logcroak $@ if $@ =~ s/\.?\n$/,/;
 	$@ = $da;
 	return $self;
@@ -413,11 +423,11 @@ sub retrieve_fd { &fd_retrieve }		# Backward compatibility
 # by freeze.  If the frozen image passed is undef, return undef.
 #
 sub thaw {
-	my ($frozen) = @_;
-	return undef unless defined $frozen;
+	my ($frozen, $flags) = @_;
+	$flags = $Storable::flags unless defined $flags;
 	my $self;
 	my $da = $@;							# Could be from exception handler
-	eval { $self = mretrieve($frozen) };	# Call C routine
+	eval { $self = mretrieve($frozen, $flags) };	# Call C routine
 	logcroak $@ if $@ =~ s/\.?\n$/,/;
 	$@ = $da;
 	return $self;
@@ -460,6 +470,21 @@ Storable - persistence for Perl data structures
  lock_store \%table, 'file';
  lock_nstore \%table, 'file';
  $hashref = lock_retrieve('file');
+
+ # By default Storable save&restore tied or blessed objects
+ # you can disable this behavior by setting the custom flag to 0
+
+ $Storable::flags = 0;
+
+ # The current behavior is to allow BLESS and TIE objects
+ $Storable::flags = Storable::FLAGS_COMPAT;
+ # which is similar to
+ $Storable::flags = Storable::BLESS_OK | Storable::TIE_OK;
+
+ # you can enable one or the other
+ $Storable::flags = Storable::BLESS_OK;
+ $Storable::flags = Storable::TIE_OK;
+
 
 =head1 DESCRIPTION
 

--- a/dist/Storable/t/attach_errors.t
+++ b/dist/Storable/t/attach_errors.t
@@ -25,9 +25,7 @@ sub BEGIN {
 use Test::More tests => 40;
 use Storable ();
 
-
-
-
+$Storable::flags = Storable::FLAGS_COMPAT;
 
 #####################################################################
 # Error 1

--- a/dist/Storable/t/attach_singleton.t
+++ b/dist/Storable/t/attach_singleton.t
@@ -22,6 +22,8 @@ sub BEGIN {
 use Test::More tests => 11;
 use Storable ();
 
+$Storable::flags = Storable::FLAGS_COMPAT;
+
 # Get the singleton
 my $object = My::Singleton->new;
 isa_ok( $object, 'My::Singleton' );

--- a/dist/Storable/t/blessed.t
+++ b/dist/Storable/t/blessed.t
@@ -43,7 +43,7 @@ use Storable qw(freeze thaw store retrieve);
 }
 
 my $test = 12;
-my $tests = $test + 23 + (2 * 6 * keys %::immortals) + (3 * keys %::weird_refs);
+my $tests = $test + 21 + (2 * 6 * keys %::immortals) + (3 * keys %::weird_refs);
 plan(tests => $tests);
 
 package SHORT_NAME;
@@ -173,7 +173,6 @@ foreach $count (1..3) {
 
 package HAS_HOOK;
 
-$loaded_count = 0;
 $thawed_count = 0;
 
 sub make {
@@ -185,15 +184,19 @@ sub STORABLE_freeze {
   return '';
 }
 
+sub STORABLE_thaw {
+  my $self = shift;
+  $thawed_count++;
+  return $self;
+}
+
 package main;
 
 my $f = freeze (HAS_HOOK->make);
 
-is($HAS_HOOK::loaded_count, 0);
 is($HAS_HOOK::thawed_count, 0);
 
 my $t = thaw $f;
-is($HAS_HOOK::loaded_count, 1);
 is($HAS_HOOK::thawed_count, 1);
 isnt($t, undef);
 is(ref $t, 'HAS_HOOK');
@@ -201,8 +204,11 @@ is(ref $t, 'HAS_HOOK');
 delete $INC{"HAS_HOOK.pm"};
 delete $HAS_HOOK::{STORABLE_thaw};
 
+$t = eval { thaw $f; };
+ok($@);
+
+require HAS_HOOK;
 $t = thaw $f;
-is($HAS_HOOK::loaded_count, 2);
 is($HAS_HOOK::thawed_count, 2);
 isnt($t, undef);
 is(ref $t, 'HAS_HOOK');

--- a/dist/Storable/t/circular_hook.t
+++ b/dist/Storable/t/circular_hook.t
@@ -25,6 +25,8 @@ sub BEGIN {
 use Storable ();
 use Test::More tests => 9;
 
+$Storable::flags = Storable::FLAGS_COMPAT;
+
 my $ddd = bless { }, 'Foo';
 my $eee = bless { Bar => $ddd }, 'Bar';
 $ddd->{Foo} = $eee;

--- a/dist/Storable/t/compat06.t
+++ b/dist/Storable/t/compat06.t
@@ -20,6 +20,8 @@ use Test::More tests => 8;
 
 use Storable qw(freeze nfreeze thaw);
 
+$Storable::flags = Storable::FLAGS_COMPAT;
+
 package TIED_HASH;
 
 sub TIEHASH {

--- a/dist/Storable/t/destroy.t
+++ b/dist/Storable/t/destroy.t
@@ -8,7 +8,7 @@ package foo;
 sub new { return bless {} }
 DESTROY {
   open FH, '<', "foo" or die $!;
-  eval { Storable::pretrieve(*FH); };
+  eval { Storable::pretrieve(*FH, Storable::FLAGS_COMPAT()); };
   close FH or die $!;
   unlink "foo";
 }

--- a/dist/Storable/t/flags.t
+++ b/dist/Storable/t/flags.t
@@ -1,0 +1,103 @@
+#!./perl
+
+use Test::More tests => 16;
+
+use Storable ();
+
+use warnings;
+use strict;
+
+package TEST;
+
+sub make {
+	my $pkg = shift;
+	return bless { a => 1, b => 2 }, $pkg;
+}
+
+package TIED_HASH;
+
+sub TIEHASH {
+	my $pkg = shift;
+	return bless { a => 1, b => 2 }, $pkg;
+}
+
+sub FETCH {
+	my ($self, $key) = @_;
+	return $self->{$key};
+}
+
+sub STORE {
+	my ($self, $key, $value) = @_;
+	$self->{$key} = $value;
+}
+
+sub FIRSTKEY {
+	my $self = shift;
+	keys %$self;
+	return each %$self;
+}
+
+sub NEXTKEY {
+	my $self = shift;
+	return each %{$self};
+}
+
+sub EXISTS {
+	my ($self, $key) = @_;
+	return exists $self->{$key};
+}
+
+package main;
+
+{
+	my $obj = TEST->make;
+
+	is_deeply($obj, { a => 1, b => 2 }, "object contains correct data");
+
+	my $frozen = Storable::freeze($obj);
+	my ($t1, $t2) = Storable::thaw($frozen);
+
+	{
+		no warnings 'once';
+		local $Storable::flags = Storable::FLAGS_COMPAT();
+		$t2 = Storable::thaw($frozen);
+	}
+
+	is_deeply($t1, $t2, "objects contain matching data");
+	is(ref $t1, 'TEST', "default object is blessed");
+	is(ref $t2, 'TEST', "compat object is blessed into correct class");
+
+	my $t3 = Storable::thaw($frozen, Storable::FLAGS_COMPAT());
+	is_deeply($t2, $t3, "objects contain matching data (explicit test)");
+	is(ref $t3, 'TEST', "compat object is blessed into correct class (explicit test)");
+
+	my $t4 = Storable::thaw($frozen, Storable::BLESS_OK());
+	is_deeply($t2, $t3, "objects contain matching data (explicit test for bless)");
+	is(ref $t3, 'TEST', "compat object is blessed into correct class (explicit test for bless)");
+
+	{
+		no warnings 'once';
+		local $Storable::flags = Storable::FLAGS_COMPAT();
+		my $t5 = Storable::thaw($frozen, 0);
+		my $t6 = Storable::thaw($frozen, Storable::TIE_OK());
+
+		is_deeply($t1, $t5, "objects contain matching data");
+		is_deeply($t1, $t6, "objects contain matching data for TIE_OK");
+		is(ref $t5, 'HASH', "default object is unblessed");
+		is(ref $t6, 'HASH', "TIE_OK object is unblessed");
+	}
+}
+
+{
+	tie my %hash, 'TIED_HASH';
+	ok(tied %hash, "hash is tied");
+	my $obj = { bow => \%hash };
+
+	my $frozen = Storable::freeze($obj);
+	my $t1 = Storable::thaw($frozen, Storable::FLAGS_COMPAT());
+	my $t2 = eval { Storable::thaw($frozen); };
+
+	ok(!$@, "trying to thaw a tied value succeeds");
+	ok(tied %{$t1->{bow}}, "compat object is tied");
+	is(ref tied %{$t1->{bow}}, 'TIED_HASH', "compat object is tied into correct class");
+}

--- a/dist/Storable/t/freeze.t
+++ b/dist/Storable/t/freeze.t
@@ -19,6 +19,8 @@ sub BEGIN {
 
 use Storable qw(freeze nfreeze thaw);
 
+$Storable::flags = Storable::FLAGS_COMPAT;
+
 use Test::More tests => 21;
 
 $a = 'toto';

--- a/dist/Storable/t/just_plain_nasty.t
+++ b/dist/Storable/t/just_plain_nasty.t
@@ -35,6 +35,8 @@ BEGIN {
 
 use Storable qw(freeze thaw);
 
+$Storable::flags = Storable::FLAGS_COMPAT;
+
 #$Storable::DEBUGME = 1;
 BEGIN {
     plan tests => 34;

--- a/dist/Storable/t/overload.t
+++ b/dist/Storable/t/overload.t
@@ -18,6 +18,8 @@ sub BEGIN {
 
 use Storable qw(freeze thaw);
 
+$Storable::flags = Storable::FLAGS_COMPAT;
+
 use Test::More tests => 19;
 
 package OVERLOADED;
@@ -90,6 +92,7 @@ if (ord ('A') == 193) { # EBCDIC.
 
 # see note at the end of do_retrieve in Storable.xs about why this test has to
 # use a reference to an overloaded reference, rather than just a reference.
+require HAS_OVERLOAD;
 my $t = eval {thaw $f};
 print "# $@" if $@;
 is($@, "");

--- a/dist/Storable/t/recurse.t
+++ b/dist/Storable/t/recurse.t
@@ -17,6 +17,9 @@ sub BEGIN {
 }
 
 use Storable qw(freeze thaw dclone);
+
+$Storable::flags = Storable::FLAGS_COMPAT;
+
 use Test::More tests => 33;
 
 package OBJ_REAL;

--- a/dist/Storable/t/store.t
+++ b/dist/Storable/t/store.t
@@ -19,6 +19,8 @@ sub BEGIN {
 
 use Storable qw(store retrieve store_fd nstore_fd fd_retrieve);
 
+$Storable::flags = Storable::FLAGS_COMPAT;
+
 use Test::More tests => 25;
 
 $a = 'toto';

--- a/dist/Storable/t/tied.t
+++ b/dist/Storable/t/tied.t
@@ -18,6 +18,8 @@ sub BEGIN {
 }
 
 use Storable qw(freeze thaw);
+$Storable::flags = Storable::FLAGS_COMPAT;
+
 use Test::More tests => 25;
 
 ($scalar_fetch, $array_fetch, $hash_fetch) = (0, 0, 0);

--- a/dist/Storable/t/tied_hook.t
+++ b/dist/Storable/t/tied_hook.t
@@ -18,6 +18,9 @@ sub BEGIN {
 }
 
 use Storable qw(freeze thaw);
+
+$Storable::flags = Storable::FLAGS_COMPAT;
+
 use Test::More tests => 28;
 
 ($scalar_fetch, $array_fetch, $hash_fetch) = (0, 0, 0);

--- a/dist/Storable/t/tied_items.t
+++ b/dist/Storable/t/tied_items.t
@@ -25,6 +25,8 @@ $^W = 0;
 use Storable qw(dclone);
 use Test::More tests => 8;
 
+$Storable::flags = Storable::FLAGS_COMPAT;
+
 $h_fetches = 0;
 
 sub H::TIEHASH { bless \(my $x), "H" }

--- a/dist/Storable/t/utf8hash.t
+++ b/dist/Storable/t/utf8hash.t
@@ -28,6 +28,7 @@ use Test::More tests=>144;
 use bytes ();
 my %utf8hash;
 
+$Storable::flags = Storable::FLAGS_COMPAT;
 $Storable::canonical = $Storable::canonical; # Shut up a used only once warning.
 
 for $Storable::canonical (0, 1) {

--- a/dist/Storable/t/weak.t
+++ b/dist/Storable/t/weak.t
@@ -34,6 +34,8 @@ require 'testlib.pl';
 our $file;
 use strict;
 
+$Storable::flags = Storable::FLAGS_COMPAT;
+
 sub tester {
   my ($contents, $sub, $testersub, $what) = @_;
   # Test that if we re-write it, everything still works:


### PR DESCRIPTION
    Add an optional flag in Storable namespace to control
    (allow or block) 'bless' and 'tie' when restoring objects.

    Default flag value is set to 'Storable::FLAGS_COMPAT' to preserve
    original behavior. Providing a 'FLAG_COMPAT' value would allow
    to change the default value over time.

    Setting '$Storable::flags' to '0' disable 'bless' and 'tie'.
    You can control which behavior to use by setting $Storable::flags
    to one of these values.

        $Storable::flags = Storable::BLESS_OK;
        $Storable::flags = Storable::TIE_OK;

        # disable 'bless' and 'tie'
        $Storable::flags = 0;
        # enable 'bless' and 'tie'
        $Storable::flags = Storable::FLAGS_COMPAT;