### PR TITLE
IO test: adjust require for non CORE perl

### DIFF
--- a/dist/IO/t/io_utf8argv.t
+++ b/dist/IO/t/io_utf8argv.t
@@ -5,7 +5,7 @@ BEGIN {
 	print "1..0 # Skip: not perlio\n";
 	exit 0;
     }
-    require($ENV{PERL_CORE} ? "../../t/test.pl" : "../t/test.pl");
+    require($ENV{PERL_CORE} ? "../../t/test.pl" : "./t/test.pl");
 }
 
 use utf8;
@@ -22,7 +22,7 @@ my $bytes =
             "\xcd\xbe\x0a";
 
 if ($::IS_EBCDIC) {
-    require($ENV{PERL_CORE} ? "../../t/charset_tools.pl" : "../t/charset_tools.pl");
+    require($ENV{PERL_CORE} ? "../../t/charset_tools.pl" : "./t/charset_tools.pl");
     $bytes = byte_utf8a_to_utf8n($bytes)
 }
 


### PR DESCRIPTION
fix test t/io_utf8argv.t when run outside of core perl
(noticed this on windows platform)