### PR TITLE
t/uni/caller.t should declare its plan at run time

### DIFF
--- a/t/uni/caller.t
+++ b/t/uni/caller.t
@@ -5,11 +5,12 @@ BEGIN {
     chdir 't' if -d 't';
     require './test.pl';
     set_up_inc('../lib');
-    plan( tests => 18 );
 }
 
 use utf8;
 use open qw( :utf8 :std );
+
+plan( tests => 18 );
 
 package ｍａｉｎ;
 


### PR DESCRIPTION
Unit test should declare their test plan after
compilation when possible.